### PR TITLE
readme: make rpm install more visible for Centos only OSs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,30 +22,15 @@ To start with compiling [YODAOS][], a Linux is required, we recommend the follow
 For Ubuntu:
 
 ```sh
-$ apt-get install build-essential subversion libncurses5-dev zlib1g-dev gawk gcc-multilib flex git-core gettext libssl-dev unzip texinfo device-tree-compiler dosfstools libusb-1.0-0-dev alien
+$ apt-get install build-essential subversion libncurses5-dev zlib1g-dev gawk gcc-multilib flex git-core gettext libssl-dev unzip texinfo device-tree-compiler dosfstools libusb-1.0-0-dev
 ```
 
 For Centos 7, the install command-line is:
 
 ```sh
 $ yum install -y unzip bzip2 dosfstools wget gcc gcc-c++ git ncurses-devel zlib-static openssl-devel svn patch perl-Module-Install.noarch perl-Thread-Queue
-```
-
-And the `device-tree-compiler` also needs to install manually:
-
-```sh
+# And the `device-tree-compiler` also needs to install manually:
 $ wget http://www.rpmfind.net/linux/epel/6/x86_64/Packages/d/dtc-1.4.0-1.el6.x86_64.rpm
-```
-
-For Ubuntu:
-
-```sh
-$ alien -d dtc-1.4.0-1.el6.x86_64.rpm
-$ alien dtc_1.4.0-2_amd64.deb
-```
-
-For Centos 7:
-```sh
 $ rpm -i dtc-1.4.0-1.el6.x86_64.rpm
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,25 @@ $ apt-get install build-essential subversion libncurses5-dev zlib1g-dev gawk gcc
 For Centos 7, the install command-line is:
 
 ```sh
-$ yum install -y unzip bzip2 dosfstools wget gcc gcc-c++ git ncurses-devel zlib-static openssl-devel svn patch perl-Module-Install.noarch perl-Thread-Queue alien
+$ yum install -y unzip bzip2 dosfstools wget gcc gcc-c++ git ncurses-devel zlib-static openssl-devel svn patch perl-Module-Install.noarch perl-Thread-Queue
 ```
 
 And the `device-tree-compiler` also needs to install manually:
 
 ```sh
 $ wget http://www.rpmfind.net/linux/epel/6/x86_64/Packages/d/dtc-1.4.0-1.el6.x86_64.rpm
-$ alien -d dtc-1.4.0-1.el6.x86_64.rpm # Ubuntu only
+```
+
+For Ubuntu:
+
+```sh
+$ alien -d dtc-1.4.0-1.el6.x86_64.rpm
 $ alien dtc_1.4.0-2_amd64.deb
+```
+
+For Centos 7:
+```sh
+$ rpm -i dtc-1.4.0-1.el6.x86_64.rpm
 ```
 
 ### Download Source

--- a/README.md
+++ b/README.md
@@ -22,20 +22,21 @@ To start with compiling [YODAOS][], a Linux is required, we recommend the follow
 For Ubuntu:
 
 ```sh
-$ apt-get install build-essential subversion libncurses5-dev zlib1g-dev gawk gcc-multilib flex git-core gettext libssl-dev unzip texinfo device-tree-compiler dosfstools libusb-1.0-0-dev
+$ apt-get install build-essential subversion libncurses5-dev zlib1g-dev gawk gcc-multilib flex git-core gettext libssl-dev unzip texinfo device-tree-compiler dosfstools libusb-1.0-0-dev alien
 ```
 
 For Centos 7, the install command-line is:
 
 ```sh
-$ yum install -y unzip bzip2 dosfstools wget gcc gcc-c++ git ncurses-devel zlib-static openssl-devel svn patch perl-Module-Install.noarch perl-Thread-Queue
+$ yum install -y unzip bzip2 dosfstools wget gcc gcc-c++ git ncurses-devel zlib-static openssl-devel svn patch perl-Module-Install.noarch perl-Thread-Queue alien
 ```
 
 And the `device-tree-compiler` also needs to install manually:
 
 ```sh
 $ wget http://www.rpmfind.net/linux/epel/6/x86_64/Packages/d/dtc-1.4.0-1.el6.x86_64.rpm
-$ rpm -i dtc-1.4.0-1.el6.x86_64.rpm
+$ alien -d dtc-1.4.0-1.el6.x86_64.rpm # Ubuntu only
+$ alien dtc_1.4.0-2_amd64.deb
 ```
 
 ### Download Source


### PR DESCRIPTION
Hi,

When I try to use `rpm` on Ubuntu, I get this message:

```sh
ubuntu@8774fd3217cb:~$ sudo rpm -i dtc-1.4.0-1.el6.x86_64.rpm
rpm: RPM should not be used directly install RPM packages, use Alien instead!
rpm: However assuming you know what you are doing...
warning: dtc-1.4.0-1.el6.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 0608b895: NOKEY
```

I hope this helps. 

Cheers,
G.